### PR TITLE
Add a verbose option, and also fix for xcresulttool needing the --legacy flag (due to deprecation).

### DIFF
--- a/libxcode/src/main/groovy/org/openbakery/test/XCResultTool.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/test/XCResultTool.groovy
@@ -18,6 +18,7 @@ class XCResultTool {
 		logger.info("load result file {}", file)
 		def runner = new CommandRunner()
 		def commandList = [path, "get",
+											 "--legacy",
 											 "--format", "json",
 											 "--path", file.absolutePath]
 
@@ -36,6 +37,7 @@ class XCResultTool {
 	void exportAttachment(File from, File to, String id, String name) {
 		def runner = new CommandRunner()
 		runner.run(path, "export",
+			"--legacy",
 			"--path", from.absolutePath,
 			"--id", id,
 			"--output-path", "${to.absolutePath}/${name}",

--- a/libxcode/src/main/groovy/org/openbakery/xcode/Xcodebuild.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/xcode/Xcodebuild.groovy
@@ -57,7 +57,7 @@ class Xcodebuild {
 		addDestinationSettings(commandList)
 		addDisableIndexing(commandList)
 
-		commandRunner.run(projectDirectory.absolutePath, commandList, environment, outputAppender)
+		commandRunner.run(projectDirectory.absolutePath, commandList, environment, outputAppender, parameters.verbose)
 	}
 
 	def commandListForTest(OutputAppender outputAppender, Map<String, String> environment) {
@@ -89,7 +89,7 @@ class Xcodebuild {
 	def executeBuildForTesting(OutputAppender outputAppender, Map<String, String> environment) {
 		def commandList = commandListForTest(outputAppender, environment)
 		commandList << "build-for-testing"
-		commandRunner.run(this.projectDirectory.absolutePath, commandList, environment, outputAppender)
+		commandRunner.run(this.projectDirectory.absolutePath, commandList, environment, outputAppender, parameters.verbose)
 	}
 
 	def executeTestWithoutBuilding(OutputAppender outputAppender, Map<String, String> environment) {
@@ -165,6 +165,10 @@ class Xcodebuild {
 				commandList.add(parameters.projectFile)
 			}
 			
+		}
+
+		if (parameters.verbose) {
+			commandList.add("-verbose")
 		}
 
 		if (parameters.bitcode) {

--- a/libxcode/src/main/groovy/org/openbakery/xcode/XcodebuildParameters.groovy
+++ b/libxcode/src/main/groovy/org/openbakery/xcode/XcodebuildParameters.groovy
@@ -26,6 +26,7 @@ class XcodebuildParameters {
 	List<File> xctestrun
 	Boolean bitcode
 	File applicationBundle
+	Boolean verbose
 
 
 	public XcodebuildParameters() {
@@ -52,6 +53,7 @@ class XcodebuildParameters {
 						", configuredDestinations=" + configuredDestinations +
 						", xctestrun=" + xctestrun +
 						", applicationBundle=" + applicationBundle +
+						", verbose=" + verbose +
 						'}'
 	}
 
@@ -93,6 +95,9 @@ class XcodebuildParameters {
 		}
 		if (other.applicationBundle != null) {
 			applicationBundle = other.applicationBundle
+		}
+		if (other.verbose != null) {
+			verbose = other.verbose
 		}
 
 		return this

--- a/libxcode/src/test/groovy/org/openbakery/xcode/XcodebuildSpecification.groovy
+++ b/libxcode/src/test/groovy/org/openbakery/xcode/XcodebuildSpecification.groovy
@@ -135,7 +135,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = createCommandWithDerivedDataPath_And_DefaultDirectories('xcodebuild',
 							"-scheme", 'myscheme',
@@ -167,7 +167,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = ['xcodebuild',
 														 "-scheme", 'myscheme',
@@ -197,7 +197,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = createCommandWithDefaultDirectories('xcodebuild',
 							"-configuration", "Debug",
@@ -221,7 +221,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = createCommandWithDerivedDataPath_And_DefaultDirectories('xcodebuild',
 							"-scheme", 'myscheme',
@@ -245,7 +245,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = createCommandWithDerivedDataPath_And_DefaultDirectories('xcodebuild',
 							"-scheme", 'myscheme',
@@ -271,7 +271,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = createCommandWithDerivedDataPath_DefaultDirectories_forSimulator('xcodebuild',
 							"-scheme", 'myscheme',
@@ -298,7 +298,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList << 'xcodebuild'
 			expectedCommandList <<"-scheme" << 'myscheme'
@@ -327,7 +327,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList << 'xcodebuild'
 			expectedCommandList <<"-scheme" << 'myscheme'
@@ -353,7 +353,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = createCommandWithDerivedDataPath_DefaultDirectories_forSimulator('xcodebuild',
 							"-scheme", 'myscheme',
@@ -379,7 +379,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = createCommandWithDefaultDirectories('xcodebuild',
 							"-configuration", "Debug",
@@ -405,7 +405,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = createCommandWithDerivedDataPath_DefaultDirectories_forSimulator('xcodebuild',
 							"-scheme", 'myscheme',
@@ -431,7 +431,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 
 			expectedCommandList << 'xcodebuild'
@@ -463,7 +463,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = createCommandWithDefaultDirectories(xcodeDummy.xcodebuild.absolutePath,
 							"-configuration", 'Debug',
@@ -479,7 +479,7 @@ class XcodebuildSpecification extends Specification {
 
 		given:
 		xcodebuild.parameters.target = "Test"
-		commandRunner.run(_, _, _, _) >> {
+		commandRunner.run(_, _, _, _, _) >> {
 			throw new CommandRunnerException()
 		}
 
@@ -505,7 +505,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = []
 			expectedCommandList << 'xcodebuild' << "-scheme" << 'myscheme' << "-workspace" << 'myworkspace' << "-configuration" << "Debug"
@@ -530,7 +530,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = []
 			expectedCommandList << 'xcodebuild' << "-scheme" << 'myscheme' << "-workspace" << 'myworkspace' << "-configuration" << "Debug"
@@ -552,7 +552,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> directory = arguments[0] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> directory = arguments[0] }
 		directory.endsWith("foobar")
 	}
 
@@ -589,7 +589,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> givenOutputAppender = arguments[3] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> givenOutputAppender = arguments[3] }
 		givenOutputAppender == outputAppender
 	}
 
@@ -708,7 +708,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 
 
 		interaction {
@@ -779,7 +779,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = createCommandWithDefaultDirectories('xcodebuild',
 							"-configuration", "Debug",
@@ -901,7 +901,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.executeBuildForTesting(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
 		command.startsWith("script -q /dev/null xcodebuild")
 		command.contains("-scheme myscheme")
 		command.contains("-workspace myworkspace")
@@ -965,7 +965,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments ->
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments ->
 			directory = arguments[0]
 			commandList = arguments[1]
 		}
@@ -1005,7 +1005,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.executeBuildForTesting(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> directory = arguments[0] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> directory = arguments[0] }
 		directory.endsWith("foobar")
 	}
 
@@ -1051,7 +1051,7 @@ class XcodebuildSpecification extends Specification {
 
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		commandList.contains('OTHER_CFLAGS="-fembed-bitcode"')
 		commandList.contains('BITCODE_GENERATION_MODE=bitcode')
 	}
@@ -1069,7 +1069,7 @@ class XcodebuildSpecification extends Specification {
 
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		!commandList.contains('OTHER_CFLAGS="-fembed-bitcode"')
 		!commandList.contains('BITCODE_GENERATION_MODE=bitcode')
 	}
@@ -1087,7 +1087,7 @@ class XcodebuildSpecification extends Specification {
 
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		commandList.contains('COMPILER_INDEX_STORE_ENABLE=NO')
 	}
 
@@ -1145,7 +1145,7 @@ class XcodebuildSpecification extends Specification {
 		xcodebuild.execute(outputAppender, null)
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments ->
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments ->
 			command = arguments[1].join(" ")
 		}
 		command.contains("-destination generic/platform=iOS")

--- a/xcode-plugin/src/main/groovy/org/openbakery/AbstractXcodeBuildTask.groovy
+++ b/xcode-plugin/src/main/groovy/org/openbakery/AbstractXcodeBuildTask.groovy
@@ -159,11 +159,11 @@ abstract class AbstractXcodeBuildTask extends AbstractXcodeTask {
 	}
 
 
-	XcodeBuildOutputAppender createXcodeBuildOutputAppender(String name) {
+	XcodeBuildOutputAppender createXcodeBuildOutputAppender(String name, Boolean verbose = false) {
 		StyledTextOutput output = getServices().get(StyledTextOutputFactory.class).create(XcodeBuildTask.class, LogLevel.LIFECYCLE);
 		ProgressLoggerFactory progressLoggerFactory = getServices().get(ProgressLoggerFactory.class) as ProgressLoggerFactory;
 		ProgressLogger progressLogger = progressLoggerFactory.newOperation(XcodeBuildTask.class).start(name, name);
-		return new XcodeBuildOutputAppender(progressLogger, output)
+		return new XcodeBuildOutputAppender(progressLogger, output, verbose)
 	}
 
 }

--- a/xcode-plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
+++ b/xcode-plugin/src/main/groovy/org/openbakery/XcodeBuildPluginExtension.groovy
@@ -94,6 +94,7 @@ class XcodeBuildPluginExtension {
 	File projectFile
 
 	Boolean bitcode = false
+	Boolean verbose = false
 
 	boolean useXcodebuildArchive = false
 
@@ -478,6 +479,7 @@ class XcodeBuildPluginExtension {
 		result.configuredDestinations = this.destinations
 		result.bitcode = this.bitcode
 		result.applicationBundle = getApplicationBundle()
+		result.verbose = this.verbose
 
 		if (this.arch != null) {
 			result.arch = this.arch.clone()

--- a/xcode-plugin/src/main/groovy/org/openbakery/XcodeBuildTask.groovy
+++ b/xcode-plugin/src/main/groovy/org/openbakery/XcodeBuildTask.groovy
@@ -54,7 +54,7 @@ class XcodeBuildTask extends AbstractXcodeBuildTask {
 
 		Xcodebuild xcodebuild = new Xcodebuild(project.projectDir, commandRunner, xcode, parameters, getDestinations())
 
-		xcodebuild.execute(createXcodeBuildOutputAppender("XcodeBuildTask") , project.xcodebuild.environment)
+		xcodebuild.execute(createXcodeBuildOutputAppender("XcodeBuildTask", parameters.verbose) , project.xcodebuild.environment)
 		logger.lifecycle("Done")
 	}
 

--- a/xcode-plugin/src/main/groovy/org/openbakery/output/XcodeBuildOutputAppender.groovy
+++ b/xcode-plugin/src/main/groovy/org/openbakery/output/XcodeBuildOutputAppender.groovy
@@ -24,12 +24,14 @@ class XcodeBuildOutputAppender implements OutputAppender {
 	boolean fullProgress = false
 	OutputState outputState = OutputState.OK
 	ProgressLogger progressLogger
+	Boolean verbose = false
 
 	StyledTextOutput output
 
-	XcodeBuildOutputAppender(ProgressLogger progressLogger, StyledTextOutput output) {
+	XcodeBuildOutputAppender(ProgressLogger progressLogger, StyledTextOutput output, Boolean verbose = false) {
 		this.output = output
 		this.progressLogger = progressLogger
+		this.verbose = verbose
 		reset()
 	}
 
@@ -244,6 +246,10 @@ class XcodeBuildOutputAppender implements OutputAppender {
 				output.withStyle(StyledTextOutput.Style.Identifier).text("\n")
 				break
 			default:
+				if (verbose) {
+					output.text(line)
+					output.text("\n")
+				}
 				break
 		}
 

--- a/xcode-plugin/src/test/groovy/org/openbakery/XcodeBuildForTestTaskSpecification.groovy
+++ b/xcode-plugin/src/test/groovy/org/openbakery/XcodeBuildForTestTaskSpecification.groovy
@@ -98,7 +98,7 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		xcodeBuildForTestTask.buildForTest()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		commandList.contains("build-for-testing")
 		commandList.contains("myscheme")
 	}
@@ -111,7 +111,7 @@ class XcodeBuildForTestTaskSpecification extends Specification {
 		xcodeBuildForTestTask.buildForTest()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> outputAppender = arguments[3] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> outputAppender = arguments[3] }
 		outputAppender instanceof XcodeBuildOutputAppender
 	}
 

--- a/xcode-plugin/src/test/groovy/org/openbakery/XcodeBuildTaskSpecification.groovy
+++ b/xcode-plugin/src/test/groovy/org/openbakery/XcodeBuildTaskSpecification.groovy
@@ -138,7 +138,7 @@ class XcodeBuildTaskSpecification extends Specification {
 		xcodeBuildTask.build()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
 		command.startsWith("xcodebuild -scheme myscheme")
 		command.contains("-workspace myworkspace")
 		command.contains("-configuration Debug")
@@ -165,7 +165,7 @@ class XcodeBuildTaskSpecification extends Specification {
 		xcodeBuildTask.build()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
 
 		command.startsWith("xcodebuild -scheme myscheme")
 		command.contains("-workspace myworkspace")
@@ -189,7 +189,7 @@ class XcodeBuildTaskSpecification extends Specification {
 		xcodeBuildTask.build()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
 		command.startsWith("xcodebuild -configuration Debug")
 		command.contains(" -target mytarget")
 		command.contains("-destination platform=iOS Simulator,id=5F371E1E-AFCE-4589-9158-8C439A468E61")
@@ -208,7 +208,7 @@ class XcodeBuildTaskSpecification extends Specification {
 		xcodeBuildTask.build()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
 		command.contains("-project")
 		command.contains(projectFile)
 	}
@@ -226,7 +226,7 @@ class XcodeBuildTaskSpecification extends Specification {
 		xcodeBuildTask.build()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = ['xcodebuild',
 														 "-scheme", 'myscheme',
@@ -254,7 +254,7 @@ class XcodeBuildTaskSpecification extends Specification {
 		xcodeBuildTask.build()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = ['xcodebuild',
 														 "-scheme", 'myscheme',
@@ -283,7 +283,7 @@ class XcodeBuildTaskSpecification extends Specification {
 		xcodeBuildTask.build()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
 		command.startsWith("xcodebuild -scheme myscheme")
 		command.contains("-workspace myworkspace")
 		command.contains("-configuration Debug")
@@ -310,7 +310,7 @@ class XcodeBuildTaskSpecification extends Specification {
 		xcodeBuildTask.build()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> commandList = arguments[1] }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> commandList = arguments[1] }
 		interaction {
 			expectedCommandList = ['xcodebuild',
 														 "-scheme", 'myscheme',
@@ -336,7 +336,7 @@ class XcodeBuildTaskSpecification extends Specification {
 		xcodeBuildTask.build()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
 		command.startsWith("xcodebuild -scheme myscheme")
 		command.contains("-workspace myworkspace")
 		command.contains("-configuration Debug")
@@ -356,7 +356,7 @@ class XcodeBuildTaskSpecification extends Specification {
 		xcodeBuildTask.build()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
 		command.startsWith("xcodebuild -configuration Debug -target mytarget")
 		command.contains(expectedDefaultDirectories().join(" "))
 		command.contains("-destination platform=iOS Simulator,id=5F371E1E-AFCE-4589-9158-8C439A468E61")
@@ -374,7 +374,7 @@ class XcodeBuildTaskSpecification extends Specification {
 		xcodeBuildTask.build()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
 		command.startsWith("xcodebuild -scheme myscheme -workspace myworkspace -configuration Debug")
 		command.contains(expectedDerivedDataPath().join(" "))
 		command.contains(expectedDefaultDirectories().join(" "))
@@ -394,7 +394,7 @@ class XcodeBuildTaskSpecification extends Specification {
 		xcodeBuildTask.build()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
 		command.startsWith("xcodebuild -scheme myscheme -workspace myworkspace -configuration Debug ")
 		command.contains(" ARCHS=i386 ")
 		command.contains(expectedDerivedDataPath().join(" "))
@@ -419,7 +419,7 @@ class XcodeBuildTaskSpecification extends Specification {
 		xcodeBuildTask.build()
 
 		then:
-		1 * commandRunner.run(_, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
+		1 * commandRunner.run(_, _, _, _, _) >> { arguments -> command = arguments[1].join(" ") }
 		command.startsWith(xcodeDummy.xcodebuild.absolutePath + " -configuration Debug -target mytarget")
 		command.contains(expectedDefaultDirectories().join(" "))
 		command.contains(" -destination platform=iOS Simulator,id=5F371E1E-AFCE-4589-9158-8C439A468E61")
@@ -442,7 +442,7 @@ class XcodeBuildTaskSpecification extends Specification {
 
 		given:
 		project.xcodebuild.target = "Test"
-		commandRunner.run(_, _, _, _) >> {
+		commandRunner.run(_, _, _, _, _) >> {
 			throw new CommandRunnerException()
 		}
 


### PR DESCRIPTION
Ran all tests in the root and all tests in `example/iOS/Example`. Also tested an artificial failure in the example.